### PR TITLE
Feature[#3] : 키워드, 하모니룸, 캘린더 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^1.13.2",
         "clsx": "^2.1.1",
         "react": "^19.2.0",
+        "react-day-picker": "^9.13.2",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
         "styled-components": "^6.3.8",
@@ -315,6 +316,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.4.1.tgz",
+      "integrity": "sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==",
+      "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
       "version": "1.4.0",
@@ -2148,6 +2155,22 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-jalali": {
+      "version": "4.1.0-0",
+      "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
+      "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -3251,6 +3274,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "9.13.2",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-9.13.2.tgz",
+      "integrity": "sha512-IMPiXfXVIAuR5Yk58DDPBC8QKClrhdXV+Tr/alBrwrHUw0qDDYB1m5zPNuTnnPIr/gmJ4ChMxmtqPdxm8+R4Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0",
+        "date-fns-jalali": "^4.1.0-0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "axios": "^1.13.2",
     "clsx": "^2.1.1",
     "react": "^19.2.0",
+    "react-day-picker": "^9.13.2",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.12.0",
     "styled-components": "^6.3.8",

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -6,6 +6,7 @@ import HarmonyRoomPage from "../pages/HarmonyRoomPage";
 import KeywordPage from "../pages/KeywordPage";
 import QnA from "../pages/QnAPage";
 import HarmonyRoomDetailPage from "../pages/HarmonyRoomDetailPage";
+import CalendarPage from "../pages/CalendarPage";
 
 
 export const router = createBrowserRouter([
@@ -18,7 +19,7 @@ export const router = createBrowserRouter([
       { path: "keywords", element: <KeywordPage /> },
       { path: "harmonyrooms", element: <HarmonyRoomPage /> },
       { path: "harmonyrooms/:roomId", element: <HarmonyRoomDetailPage /> },
-      { path: "calender", element: <HarmonyRoomPage /> },
+      { path: "calender", element: <CalendarPage/>},
       { path: "QnA", element: <QnA /> },
       { path: "notice", element: <HarmonyRoomPage /> },
       { path: "userstatistics", element: <HarmonyRoomPage /> },

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -5,6 +5,7 @@ import AccountPage from "../pages/AccountPage";
 import HarmonyRoomPage from "../pages/HarmonyRoomPage";
 import KeywordPage from "../pages/KeywordPage";
 import QnA from "../pages/QnAPage";
+import HarmonyRoomDetailPage from "../pages/HarmonyRoomDetailPage";
 
 
 export const router = createBrowserRouter([
@@ -16,6 +17,7 @@ export const router = createBrowserRouter([
       { index: true, element: <AccountPage /> },
       { path: "keywords", element: <KeywordPage /> },
       { path: "harmonyrooms", element: <HarmonyRoomPage /> },
+      { path: "harmonyrooms/:roomId", element: <HarmonyRoomDetailPage /> },
       { path: "calender", element: <HarmonyRoomPage /> },
       { path: "QnA", element: <QnA /> },
       { path: "notice", element: <HarmonyRoomPage /> },

--- a/src/pages/AccountPage.tsx
+++ b/src/pages/AccountPage.tsx
@@ -17,6 +17,9 @@ import deleteIcon from "../assets/icons/Delete.svg";
 
 const ITEMS_PER_PAGE = 7;
 
+const COLUMNS = "50px 150px 1fr";
+
+
 export default function AccountPage() {
   const {
     selectedAccounts,
@@ -115,22 +118,22 @@ export default function AccountPage() {
       </FilterSection>
 
       <TableSection>
-        <TableHeader>
-           <TableCol width="50px">
+        <TableHeader columns={COLUMNS}>
+           <TableCol>
             <StyledCheckbox
               src={isAllSelected ? checkBoxActive : checkBox}
               alt="select all"
               onClick={() => toggleSelectAll(paginatedAccountIds)}
             />
           </TableCol>
-          <TableCol width="150px">이름</TableCol>
-          <TableCol width="250px">이메일</TableCol>
+          <TableCol>이름</TableCol>
+          <TableCol>이메일</TableCol>
         </TableHeader>
 
         <TableBody>
           {paginatedAccounts.map((account) => (
-            <TableRow key={account.id}>
-              <TableCol width="50px">
+            <TableRow key={account.id} columns={COLUMNS}>
+              <TableCol>
                 <StyledCheckbox
                   src={
                     selectedAccounts.includes(account.id)
@@ -141,8 +144,8 @@ export default function AccountPage() {
                   onClick={() => toggleSelectAccount(account.id)}
                 />
               </TableCol>
-              <TableCol width="150px">{account.name}</TableCol>
-              <TableCol width="250px">{account.email}</TableCol>
+              <TableCol >{account.name}</TableCol>
+              <TableCol >{account.email}</TableCol>
             </TableRow>
           ))}
         </TableBody>

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -1,0 +1,233 @@
+import { useEffect, useMemo } from "react";
+import styled from "styled-components";
+import type { DateRange } from "react-day-picker";
+import "react-day-picker/style.css";
+import Pagination from "../shared/ui/Pagination";
+import { TableSection, TableHeader, TableBody, TableRow, TableCol } from "../shared/styles/Table";
+import { useCalendarStore } from "../shared/stores/calendar.store";
+import { MOCK_CALENDAR } from "../shared/constants/mockData";
+import CustomCalendar from "../shared/ui/CustomCalendar";
+
+const ITEMS_PER_PAGE = 7;
+const COLUMNS = "1fr 160px 160px 120px";
+
+function parseDotDate(dot: string) {
+  // "2026.01.01" -> Date
+  const [y, m, d] = dot.split(".").map(Number);
+  return new Date(y, (m ?? 1) - 1, d ?? 1);
+}
+
+function formatDot(d?: Date) {
+  if (!d) return "";
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, "0");
+  const dd = String(d.getDate()).padStart(2, "0");
+  return `${yyyy}.${mm}.${dd}`;
+}
+
+function inRange(dotDate: string, range: DateRange | undefined) {
+  if (!range?.from && !range?.to) return true;
+
+  const target = parseDotDate(dotDate);
+  target.setHours(0, 0, 0, 0);
+
+  const from = range.from ? new Date(range.from) : undefined;
+  const to = range.to ? new Date(range.to) : undefined;
+  from?.setHours(0, 0, 0, 0);
+  to?.setHours(0, 0, 0, 0);
+
+  if (from && !to) return target.getTime() === from.getTime();
+  if (!from && to) return target.getTime() === to.getTime();
+  return !!(from && to && target >= from && target <= to);
+}
+
+export default function CalendarPage() {
+  const {
+    calendars,
+    currentPage,
+    category,
+    searchTerm,
+    selectedRange,
+    setCalendars,
+    setCurrentPage,
+    setCategory,
+    setSearchTerm,
+    setSelectedRange,
+  } = useCalendarStore();
+
+  useEffect(() => {
+    setCalendars(MOCK_CALENDAR);
+  }, [setCalendars]);
+
+  /** 카테고리 옵션: "전체" + 데이터에서 유니크 추출 */
+  const categoryOptions = useMemo(() => {
+    const unique = Array.from(new Set(calendars.map((c) => c.category)));
+    return ["전체", ...unique];
+  }, [calendars]);
+
+  const filtered = useMemo(() => {
+    const s = searchTerm.trim().toLowerCase();
+
+    return calendars.filter((c) => {
+      const okCategory = category === "전체" ? true : c.category === category;
+      const okSearch = !s ? true : c.name.toLowerCase().includes(s);
+      const okDate = inRange(c.date, selectedRange);
+      return okCategory && okSearch && okDate;
+    });
+  }, [calendars, category, searchTerm, selectedRange]);
+
+  const paginated = useMemo(() => {
+    const start = (currentPage - 1) * ITEMS_PER_PAGE;
+    return filtered.slice(start, start + ITEMS_PER_PAGE);
+  }, [filtered, currentPage]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / ITEMS_PER_PAGE));
+
+  const rangeText = useMemo(() => {
+    const from = selectedRange?.from ? formatDot(selectedRange.from) : "----.--.--";
+    const to = selectedRange?.to ? formatDot(selectedRange.to) : "----.--.--";
+    return `${from} - ${to}`;
+  }, [selectedRange]);
+
+  return (
+    <Page>
+      {/* 왼쪽 리스트 */}
+      <Left>
+        <Header>
+          <Title>캘린더</Title>
+        </Header>
+
+        <TableSection>
+          <TableHeader columns={COLUMNS}>
+            <TableCol>공연 제목</TableCol>
+            <TableCol>카테고리</TableCol>
+            <TableCol>날짜</TableCol>
+            <TableCol>저장 수</TableCol>
+          </TableHeader>
+
+          <TableBody>
+            {paginated.map((c) => (
+              <TableRow key={c.id} columns={COLUMNS}>
+                <EllipsisCol title={c.name}>{c.name}</EllipsisCol>
+                <TableCol>{c.category}</TableCol>
+                <TableCol>{c.date}</TableCol>
+                <TableCol>{c.bookmarks}</TableCol>
+              </TableRow>
+            ))}
+          </TableBody>
+        </TableSection>
+
+        <PaginationWrap>
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            itemCount={filtered.length}
+            itemsPerPage={ITEMS_PER_PAGE}
+            onPageChange={setCurrentPage}
+          />
+        </PaginationWrap>
+      </Left>
+
+      {/* 오른쪽 달력 */}
+      <Right>
+        <SideCard>
+          <SideTitle>날짜</SideTitle>
+
+          <SideBlock>
+            <BlockLabel>달력</BlockLabel>
+            <RangeText>{rangeText}</RangeText>
+
+            <CustomCalendar
+                selectedRange={selectedRange}
+                onSelect={(range) => setSelectedRange(range)}
+            />
+          </SideBlock>
+        </SideCard>
+      </Right>
+    </Page>
+  );
+}
+
+const Page = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 0.3fr;
+  gap: 28px;
+  padding: 24px 32px;
+  background: ${({ theme }) => theme.colors.white};
+`;
+
+const Line = styled.div`
+  width: 20px;
+  background: ${({ theme }) => theme.colors.bg};
+`
+
+const Left = styled.div`
+  min-width: 0;
+`;
+
+const Right = styled.div`
+  border-left: 24px solid ${({ theme }) => theme.colors.bg};
+  padding-left: 32px;
+  width: 312px;
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 24px;
+`;
+
+const Title = styled.h2`
+  margin: 0;
+  font-size: 24px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.black};
+`;
+
+const PaginationWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 14px;
+`;
+
+const EllipsisCol = styled(TableCol)`
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+
+/* ---------- Right Panel ---------- */
+
+const SideCard = styled.aside`
+  display: flex;
+  flex-direction: column;
+  gap: 45px;
+`;
+
+const SideTitle = styled.div`
+  font-size: 15px;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.black};
+  margin-bottom: 8px;
+`;
+
+const SideBlock = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const BlockLabel = styled.div`
+  font-family: "Pretendard";
+  font-size: 13px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.gray_600};
+`;
+
+const RangeText = styled.div`
+  font-family: "Pretendard";
+  font-size: 13px;
+  color: ${({ theme }) => theme.colors.gray_400};
+  margin-bottom: 14px;
+`;

--- a/src/pages/HarmonyRoomDetailPage.tsx
+++ b/src/pages/HarmonyRoomDetailPage.tsx
@@ -1,0 +1,12 @@
+import { useParams } from "react-router-dom";
+
+
+export default function HarmonyRoomDetailPage() {
+    const { roomId } = useParams<{ roomId: string }>();
+    return(
+    <div>
+      <h2>하모니룸 상세</h2>
+      <p>roomId: {roomId}</p>
+    </div>
+    )
+}

--- a/src/pages/HarmonyRoomDetailPage.tsx
+++ b/src/pages/HarmonyRoomDetailPage.tsx
@@ -1,12 +1,282 @@
 import { useParams } from "react-router-dom";
+import styled from "styled-components";
+import CommonButton from "../shared/ui/CommonButton";
+import { theme } from "../shared/styles/theme";
+import img from "../assets/react.svg";
+import { LongSingleInput, MultiLineInput, ShortSingleInput } from "../shared/ui/InputField";
+import { useState } from "react";
+import Popup from "../shared/ui/Popup";
 
 
 export default function HarmonyRoomDetailPage() {
     const { roomId } = useParams<{ roomId: string }>();
+
+    const [title, setTitle] = useState("");
+    const [content, setContent] = useState("");
+    const [name, setName] = useState("");
+
+    const [isPopupOpen, setIsPopupOpen] = useState(false);
+
+    const handleNext = () => {
+      if (!title.trim() || !content.trim() || !name.trim()) return;
+
+      setIsPopupOpen(true);
+    };
+
+    const handleClosePopup = () => setIsPopupOpen(false);
+
+    const handleConfirmDelete = async () => {
+      // 여기서 API 호출/삭제 처리하면 됨
+      // await HarmonyRoomAPI.deleteRoom({ roomId, title, content, name })
+      setIsPopupOpen(false);
+    };
+
+
     return(
-    <div>
-      <h2>하모니룸 상세</h2>
-      <p>roomId: {roomId}</p>
-    </div>
+    <Container>
+      <Header>
+        <Title>상세 페이지</Title>
+      </Header>
+        <Section>
+          <InfoBlock>
+            <ProfileImgSection>
+              <ProfileImg src={img}/>
+            </ProfileImgSection>
+            <InfoWrap>
+              <InfoRow>
+                <Label backgroundColor={theme.colors.blue_light} fontColor={theme.colors.blue_normal_active}>운영자</Label>
+                <InfoText fontWeight="600">melog@gmail.com</InfoText>
+              </InfoRow>
+              <InfoRow>
+                <Label>이름</Label>
+                <InfoText>베토벤을 사랑하는 모임</InfoText>
+              </InfoRow>
+              <InfoRow>
+                <Label>키워드</Label>
+                <InfoText>#베토벤 #피아노</InfoText>
+              </InfoRow>
+              <InfoRow>
+                <Label>활동내용</Label>
+                <InfoText>베토벤 피아노를 연구하는 모임 베토벤 피아노를 연구하는 모임 베토벤 피아노를 연구하는 모임</InfoText>
+              </InfoRow>
+              <InfoRow>
+                <Label>개설일</Label>
+                <InfoText>2026.01.01</InfoText>
+              </InfoRow>
+            </InfoWrap>
+          </InfoBlock>
+          <DeleteForm>
+            <SubTitle>삭제 요청</SubTitle>
+            <FormWrap>
+              <FormCol>
+                <FormLabel>제목</FormLabel>
+                <LongSingleInput
+                  value={title}
+                  onChange={setTitle}
+                  placeholder="안녕하세요. 멜로그 서비스팀입니다."
+                />
+              </FormCol>
+              <FormCol>
+                <FormLabel>내용</FormLabel>
+                <MultiLineInput
+                  value={content}
+                  onChange={setContent}
+                  placeholder="내용을 입력해 주세요."
+                />
+              </FormCol>
+              <FormRow>
+                <FormLabel>담당자</FormLabel>
+                <ShortSingleInput
+                  value={name}
+                  onChange={setName}
+                  placeholder="이름"
+                />
+              </FormRow>
+            </FormWrap>
+          </DeleteForm>
+        </Section>
+        <ButtonWrap>
+          <CommonButton label="임시저장" size="md" variant="ghost" />
+          <CommonButton label="다음" size="md" variant="default"  onClick={handleNext}/>
+        </ButtonWrap>
+
+        <Popup
+          open={isPopupOpen}
+          onClose={handleClosePopup}
+          cancelText="취소"
+          confirmText="보내기 및 하모니룸 삭제"
+          onConfirm={handleConfirmDelete}
+          width={860}
+        >
+          <div>
+            <p>계정</p>
+            <p>melog@gmail.com</p>
+          </div>
+          
+          <div>
+            <p>제목</p>
+            <p>{title || "-"}</p>
+          </div>
+
+          <div>
+            <p>내용</p>
+            <p>{content || "-"}</p>
+          </div>
+          
+          <div>
+            <p>담당자</p>
+            <p>{name || "-"}</p>
+          </div>
+          
+        </Popup>
+    </Container>
     )
 }
+
+const Container = styled.div`
+  padding: 24px 32px;
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+`;
+
+const Title = styled.h2`
+  font-size: 24px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.black};
+  margin: 0;
+`;
+
+const Section = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 48px;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const InfoBlock = styled.div`
+  width: 60%;
+  padding: 30px 24px;
+  background-color: ${({ theme }) => theme.colors.gray_100};
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap:28px;
+  `;
+
+const ProfileImgSection = styled.div`
+  width: 120px;
+  height: 120px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 100%;
+  background-color: ${({ theme }) => theme.colors.blue_normal};
+`;
+
+const ProfileImg = styled.img`
+  width: 114px;
+  height: 114px;
+  border-radius: 100%;
+  background-color: ${({ theme }) => theme.colors.gray_100};
+`;
+const InfoWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const InfoRow = styled.div`
+  display: grid;
+  grid-template-columns: 68px 1fr;
+  gap: 14px;
+`
+const Label = styled.div<{backgroundColor?: string, fontColor?: string}>`
+  height: 32px;
+  font-family: "Pretendard";
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 22px;
+  letter-spacing: -0.02em;
+  background-color: ${({ backgroundColor, theme }) => backgroundColor || theme.colors.white};
+  border-radius: 28px;
+  padding: 2px 10px;
+  color: ${({ fontColor, theme }) => fontColor || theme.colors.gray_400};
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const InfoText = styled.div<{fontWeight?: string}>`
+  font-family: "Pretendard";
+  font-size: 18px;
+  font-weight: ${({ fontWeight }) => fontWeight || "400"};
+  line-height: 28px;
+  letter-spacing: -0.01em;
+  color: ${({ theme }) => theme.colors.gray_500};
+`;
+
+const DeleteForm = styled.div`
+  width: 100%;
+  padding: 30px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap:28px;
+`;
+
+const SubTitle = styled.p`
+  font-family: "Pretendard";
+  font-size: 18px;
+  font-weight: 700;
+  line-height: 28px;
+  color: ${({ theme }) => theme.colors.black};
+  margin:0;
+  padding:0;
+`;
+
+const FormWrap = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+`;
+
+const FormCol = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+`;
+
+const FormRow = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+`;
+
+const FormLabel = styled.p`
+  font-family: "Pretendard";
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 22px;
+  letter-spacing: -0.02em;
+  color: ${({theme }) => theme.colors.gray_600};
+  margin:0;
+  padding:0;
+`;
+
+const ButtonWrap = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+`;

--- a/src/pages/HarmonyRoomPage.tsx
+++ b/src/pages/HarmonyRoomPage.tsx
@@ -1,3 +1,157 @@
+import { useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+import { useHarmonyStore } from "../shared/stores/harmony.store";
+import { MOCK_HARMONYROOM } from "../shared/constants/mockData";
+
+import SearchInput from "../shared/ui/SearchInput";
+import SearchSelect from "../shared/ui/SearchSelect";
+import CommonButton from "../shared/ui/CommonButton";
+import Pagination from "../shared/ui/Pagination";
+import { TableSection, TableHeader, TableBody, TableRow, TableCol } from "../shared/styles/Table";
+
+import chevronUp from "../assets/icons/ChevronUp.svg";
+import check from "../assets/icons/CheckIcon.svg";
+
+const ITEMS_PER_PAGE = 7;
+
+const COLUMNS = "200px 150px 1fr 120px";
+
+
 export default function HarmonyRoomPage() {
-  return <h2>하모니룸 관리</h2>;
+  const navigate = useNavigate();
+  const {
+    rooms,
+    currentPage,
+    filterType,
+    searchTerm,
+    setRooms,
+    setCurrentPage,
+    setFilterType,
+    setSearchTerm,
+  } = useHarmonyStore();
+
+  useEffect(() => {
+    setRooms(MOCK_HARMONYROOM);
+  }, [setRooms]);
+
+  const filtered = useMemo(() => {
+    return rooms.filter((r) => {
+      if (!searchTerm) return true;
+      const s = searchTerm.toLowerCase();
+      const nick = r.nickname.toLowerCase();
+      const room = r.roomName.toLowerCase();
+      switch (filterType) {
+        case "닉네임":
+          return nick.includes(s);
+        case "하모니룸 이름":
+          return room.includes(s);
+        case "닉네임 + 하모니룸 이름":
+          return nick.includes(s) || room.includes(s);
+        default:
+          return true;
+      }
+    });
+  }, [rooms, searchTerm, filterType]);
+
+  const paginated = useMemo(() => {
+    const start = (currentPage - 1) * ITEMS_PER_PAGE;
+    return filtered.slice(start, start + ITEMS_PER_PAGE);
+  }, [filtered, currentPage]);
+
+  const totalPages = Math.ceil(filtered.length / ITEMS_PER_PAGE);
+
+  const handleDetail = (roomId: number) => {
+    navigate(`/harmonyrooms/${roomId}`);
+  };
+
+  return (
+    <Container>
+      <Header>
+        <Title>하모니룸 관리</Title>
+      </Header>
+
+      <FilterSection>
+        <SearchSelect
+          options={[
+            { label: "닉네임", value: "닉네임" },
+            { label: "하모니룸 이름", value: "하모니룸 이름" },
+            { label: "닉네임 + 하모니룸 이름", value: "닉네임 + 하모니룸 이름" },
+          ]}
+          value={filterType}
+          onChange={(v) => setFilterType(v as any)}
+          placeholder="검색"
+          size={"lg"}
+          chevronUpIcon={chevronUp}
+          chevronDownIcon={chevronUp}
+          checkIcon={check}
+        />
+
+        <SearchInput placeholder="검색" value={searchTerm} on-Change={setSearchTerm} />
+
+        <div />
+      </FilterSection>
+
+      <TableSection>
+        <TableHeader columns={COLUMNS}>
+          <TableCol>닉네임</TableCol>
+          <TableCol>구분</TableCol>
+          <TableCol>하모니룸 이름</TableCol>
+          <TableCol/>
+        </TableHeader>
+
+        <TableBody>
+          {paginated.map((r) => (
+            <TableRow key={r.id} columns={COLUMNS}>
+              <TableCol>{r.nickname}</TableCol>
+              <TableCol>{r.role === "owner" ? "운영자" : "일반 회원"}</TableCol>
+              <TableCol>{r.roomName}</TableCol>
+              <TableCol>
+                {r.role === "owner" && (
+                  <CommonButton label="자세히 보기" variant="ghostGray" size="sm" onClick={() => handleDetail(r.roomId)} />
+                )}
+              </TableCol>
+            </TableRow>
+          ))}
+        </TableBody>
+      </TableSection>
+
+      <PaginationWrapper>
+        <Pagination currentPage={currentPage} totalPages={totalPages} itemCount={filtered.length} itemsPerPage={ITEMS_PER_PAGE} onPageChange={setCurrentPage} />
+      </PaginationWrapper>
+    </Container>
+  );
 }
+
+const Container = styled.div`
+  padding: 24px 72px;
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+`;
+
+const Title = styled.h2`
+  font-size: 24px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.black};
+  margin: 0;
+`;
+
+const FilterSection = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-bottom: 24px;
+`;
+
+const PaginationWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;

--- a/src/pages/HarmonyRoomPage.tsx
+++ b/src/pages/HarmonyRoomPage.tsx
@@ -108,7 +108,7 @@ export default function HarmonyRoomPage() {
               <TableCol>{r.roomName}</TableCol>
               <TableCol>
                 {r.role === "owner" && (
-                  <CommonButton label="자세히 보기" variant="ghostGray" size="sm" onClick={() => handleDetail(r.roomId)} />
+                  <CommonButton label="자세히 보기" variant="ghostGray" size="md" onClick={() => handleDetail(r.roomId)} />
                 )}
               </TableCol>
             </TableRow>

--- a/src/pages/KeywordPage.tsx
+++ b/src/pages/KeywordPage.tsx
@@ -1,3 +1,197 @@
+import { useEffect, useMemo } from "react";
+import styled from "styled-components";
+import { useKeywordStore } from "../shared/stores/keyword.store";
+import { MOCK_KEYWORDS } from "../shared/constants/mockData";
+
+import SearchInput from "../shared/ui/SearchInput";
+import SearchSelect from "../shared/ui/SearchSelect";
+import CommonButton from "../shared/ui/CommonButton";
+import Pagination from "../shared/ui/Pagination";
+import { StyledCheckbox, TableSection, TableHeader, TableBody, TableRow, TableCol} from "../shared/styles/Table";
+
+import chevronUp from "../assets/icons/ChevronUp.svg";
+import check from "../assets/icons/CheckIcon.svg";
+import checkBoxActive from "../assets/icons/CheckBoxActivate.svg";
+import checkBox from "../assets/icons/CheckBox.svg";
+import deleteIcon from "../assets/icons/Delete.svg";
+
+const ITEMS_PER_PAGE = 7;
+
+const COLUMNS = "50px 150px 150px 1fr";
+
+
 export default function KeywordPage() {
-  return <h2>키워드 관리</h2>;
+  const {
+    selectedKeywords,
+    keywords,
+    currentPage,
+    filterType,
+    searchTerm,
+    toggleSelectKeyword,
+    toggleSelectAll,
+    setCurrentPage,
+    setFilterType,
+    setSearchTerm,
+    setKeywords,
+    deleteKeywords,
+  } = useKeywordStore();
+
+  useEffect(() => {
+    setKeywords(MOCK_KEYWORDS);
+  }, [setKeywords]);
+
+  const filteredKeywords = useMemo(() => {
+    return keywords.filter((kw) => {
+      if (!searchTerm) return true;
+
+      const searchLower = searchTerm.toLowerCase();
+      const nameLower = kw.name.toLowerCase();
+      const categoryLower = kw.category.toLowerCase();
+
+      switch (filterType) {
+        case "이름":
+          return nameLower.includes(searchLower);
+        case "구분":
+          return categoryLower.includes(searchLower);
+        case "키워드":
+          return (
+            nameLower.includes(searchLower) || categoryLower.includes(searchLower)
+          );
+        default:
+          return true;
+      }
+    });
+  }, [keywords, searchTerm, filterType]);
+
+  const paginatedKeywords = useMemo(() => {
+    const startIdx = (currentPage - 1) * ITEMS_PER_PAGE;
+    return filteredKeywords.slice(startIdx, startIdx + ITEMS_PER_PAGE);
+  }, [filteredKeywords, currentPage]);
+
+  const totalPages = Math.ceil(filteredKeywords.length / ITEMS_PER_PAGE);
+  const paginatedKeywordIds = paginatedKeywords.map((k) => k.id);
+  const isAllSelected =
+    paginatedKeywordIds.length > 0 &&
+    paginatedKeywordIds.every((id) => selectedKeywords.includes(id));
+
+  const handleDelete = () => {
+    deleteKeywords(selectedKeywords);
+  };
+
+  return (
+    <Container>
+      <Header>
+        <Title>키워드 관리</Title>
+      </Header>
+
+      <FilterSection>
+        <SearchSelect
+          options={[
+            { label: "이름", value: "이름" },
+            { label: "구분", value: "구분" },
+            { label: "키워드", value: "키워드" },
+          ]}
+          value={filterType}
+          onChange={(value) => setFilterType(value as any)}
+          placeholder="키워드"
+          size={"lg"}
+          chevronUpIcon={chevronUp}
+          chevronDownIcon={chevronUp}
+          checkIcon={check}
+        />
+
+        <SearchInput
+          placeholder="검색"
+          value={searchTerm}
+          on-Change={setSearchTerm}
+        />
+
+        <CommonButton
+          label={`${selectedKeywords.length}개 삭제`}
+          variant="outline"
+          size="sm"
+          icon={deleteIcon}
+          iconPosition="right"
+          onClick={handleDelete}
+        />
+      </FilterSection>
+
+      <TableSection>
+        <TableHeader columns={COLUMNS}>
+          <TableCol>
+            <StyledCheckbox
+              src={isAllSelected ? checkBoxActive : checkBox}
+              alt="select all"
+              onClick={() => toggleSelectAll(paginatedKeywordIds)}
+            />
+          </TableCol>
+          <TableCol>이름</TableCol>
+          <TableCol>구분</TableCol>
+          <TableCol>데이터</TableCol>
+        </TableHeader>
+
+        <TableBody>
+          {paginatedKeywords.map((kw) => (
+            <TableRow key={kw.id} columns={COLUMNS}>
+              <TableCol >
+                <StyledCheckbox
+                  src={
+                    selectedKeywords.includes(kw.id) ? checkBoxActive : checkBox
+                  }
+                  alt="select"
+                  onClick={() => toggleSelectKeyword(kw.id)}
+                />
+              </TableCol>
+              <TableCol>{kw.name}</TableCol>
+              <TableCol>{kw.category}</TableCol>
+              <TableCol>{kw.keywords.join(", ")}</TableCol>
+            </TableRow>
+          ))}
+        </TableBody>
+      </TableSection>
+
+      <PaginationWrapper>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          itemCount={filteredKeywords.length}
+          itemsPerPage={ITEMS_PER_PAGE}
+          onPageChange={setCurrentPage}
+        />
+      </PaginationWrapper>
+    </Container>
+  );
 }
+
+const Container = styled.div`
+  padding: 24px 72px;
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+`;
+
+const Title = styled.h2`
+  font-size: 24px;
+  font-weight: 700;
+  color: ${({ theme }) => theme.colors.black};
+  margin: 0;
+`;
+
+const FilterSection = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-bottom: 24px;
+`;
+
+const PaginationWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+`;

--- a/src/pages/QnAPage.tsx
+++ b/src/pages/QnAPage.tsx
@@ -17,7 +17,7 @@ import upTriangle from "../assets/icons/UpTriangle.svg";
 
 const ITEMS_PER_PAGE = 7;
 
-const COLUMNS = "50px 100px 180px 160px 1fr 150px 100px";
+const COLUMNS = "50px 100px 180px 140px 1fr 120px 100px";
 
 
 export default function QnAPage() {
@@ -175,7 +175,7 @@ export default function QnAPage() {
               <TableCol>{qna.name}</TableCol>
               <TableCol>{qna.email}</TableCol>
               <TableCol>{qna.category}</TableCol>
-              <TableCol>{qna.content}</TableCol>
+              <TableCol ellipsis={true}>{qna.content}</TableCol>
               <TableCol>{qna.date}</TableCol>
               <TableCol>
                 <CommonButton label={qna.status} size="sm" variant={qna.status === "답변완료" ? "ghost" : "default"}/>

--- a/src/pages/QnAPage.tsx
+++ b/src/pages/QnAPage.tsx
@@ -17,6 +17,9 @@ import upTriangle from "../assets/icons/UpTriangle.svg";
 
 const ITEMS_PER_PAGE = 7;
 
+const COLUMNS = "50px 100px 180px 160px 1fr 150px 100px";
+
+
 export default function QnAPage() {
   const [qnas, setQnas] = useState<QnA[]>([]);
   const [selectedQnas, setSelectedQnas] = useState<number[]>([]);
@@ -128,17 +131,17 @@ export default function QnAPage() {
       </FilterSection>
 
       <TableSection>
-        <TableHeader>
-          <TableCol width="50px">
+        <TableHeader columns={COLUMNS}>
+          <TableCol>
             <StyledCheckbox
               src={isAllSelected ? checkBoxActive : checkBox}
               alt="select all"
               onClick={() => toggleSelectAll(paginatedQnaIds)}
             />
           </TableCol>
-          <TableCol width="100px">이름</TableCol>
-          <TableCol width="180px">이메일</TableCol>
-          <TableCol width="160px">
+          <TableCol>이름</TableCol>
+          <TableCol>이메일</TableCol>
+          <TableCol>
             <TableFilter
               options={[
                 { label: "서비스 문의", value: "서비스 문의" },
@@ -152,15 +155,15 @@ export default function QnAPage() {
               checkIcon={check}
             />
           </TableCol>
-          <TableCol width="350px">내용</TableCol>
-          <TableCol width="150px">날짜</TableCol>
-          <TableCol width="100px">상태</TableCol>
+          <TableCol>내용</TableCol>
+          <TableCol>날짜</TableCol>
+          <TableCol>상태</TableCol>
         </TableHeader>
 
         <TableBody>
           {paginatedQnas.map((qna) => (
-            <TableRow key={qna.id}>
-              <TableCol width="50px">
+            <TableRow key={qna.id} columns={COLUMNS}>
+              <TableCol >
                 <StyledCheckbox
                   src={
                     selectedQnas.includes(qna.id) ? checkBoxActive : checkBox
@@ -169,12 +172,12 @@ export default function QnAPage() {
                   onClick={() => toggleSelectQna(qna.id)}
                 />
               </TableCol>
-              <TableCol width="100px">{qna.name}</TableCol>
-              <TableCol width="180px">{qna.email}</TableCol>
-              <TableCol width="160px">{qna.category}</TableCol>
-              <TableCol width="350px">{qna.content}</TableCol>
-              <TableCol width="150px">{qna.date}</TableCol>
-              <TableCol width="100px">
+              <TableCol>{qna.name}</TableCol>
+              <TableCol>{qna.email}</TableCol>
+              <TableCol>{qna.category}</TableCol>
+              <TableCol>{qna.content}</TableCol>
+              <TableCol>{qna.date}</TableCol>
+              <TableCol>
                 <CommonButton label={qna.status} size="sm" variant={qna.status === "답변완료" ? "ghost" : "default"}/>
               </TableCol>
             </TableRow>

--- a/src/shared/constants/mockData.ts
+++ b/src/shared/constants/mockData.ts
@@ -136,7 +136,7 @@ export interface Keyword {
   id: number;
   name: string;
   category: string;
-  kewords: string[];
+  keywords: string[];
 }
 
 export const MOCK_KEYWORDS: Keyword[] = [
@@ -144,91 +144,91 @@ export const MOCK_KEYWORDS: Keyword[] = [
     id: 1,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 2,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 3,
     name: "아무개",
     category: "연주자",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 4,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 5,
     name: "콘트라베이스",
     category: "악기",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 6,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 7,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 8,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 9,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 10,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 11,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 12,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 13,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 14,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
   {
     id: 15,
     name: "바흐",
     category: "작곡가",
-    kewords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
+    keywords: ["온보딩", "연관검색어", "게시물", "하모니룸"]
   },
 ]
 

--- a/src/shared/stores/calendar.store.ts
+++ b/src/shared/stores/calendar.store.ts
@@ -1,0 +1,49 @@
+import { create } from "zustand";
+import type { DateRange } from "react-day-picker";
+import type { Calendar } from "../constants/mockData"
+
+type CalendarState = {
+  calendars: Calendar[];
+  currentPage: number;
+
+  /** 필터 */
+  category: string;
+  searchTerm: string;
+
+  /** DayPicker range */
+  selectedRange?: DateRange;
+
+  setCalendars: (items: Calendar[]) => void;
+  setCurrentPage: (page: number) => void;
+
+  setCategory: (category: string) => void;
+  setSearchTerm: (term: string) => void;
+
+  setSelectedRange: (range?: DateRange) => void;
+  resetFilters: () => void;
+};
+
+export const useCalendarStore = create<CalendarState>((set) => ({
+  calendars: [],
+  currentPage: 1,
+
+  category: "전체",
+  searchTerm: "",
+  selectedRange: undefined,
+
+  setCalendars: (items) => set({ calendars: items }),
+  setCurrentPage: (page) => set({ currentPage: page }),
+
+  setCategory: (category) => set({ category, currentPage: 1 }),
+  setSearchTerm: (term) => set({ searchTerm: term, currentPage: 1 }),
+
+  setSelectedRange: (range) => set({ selectedRange: range, currentPage: 1 }),
+
+  resetFilters: () =>
+    set({
+      currentPage: 1,
+      category: "전체",
+      searchTerm: "",
+      selectedRange: undefined,
+    }),
+}));

--- a/src/shared/stores/harmony.store.ts
+++ b/src/shared/stores/harmony.store.ts
@@ -1,0 +1,38 @@
+import { create } from "zustand";
+
+export type HarmonyRole = "owner" | "member";
+
+export type HarmonyRoom = {
+  id: number;
+  nickname: string;
+  role: HarmonyRole;
+  roomName: string;
+  roomId: number;
+};
+
+type HarmonyState = {
+  rooms: HarmonyRoom[];
+  currentPage: number;
+  filterType: "닉네임" | "하모니룸 이름" | "닉네임 + 하모니룸 이름";
+  searchTerm: string;
+
+  setRooms: (rooms: HarmonyRoom[]) => void;
+  setCurrentPage: (page: number) => void;
+  setFilterType: (filter: "닉네임" | "하모니룸 이름" | "닉네임 + 하모니룸 이름") => void;
+  setSearchTerm: (term: string) => void;
+};
+
+export const useHarmonyStore = create<HarmonyState>((set) => ({
+  rooms: [],
+  currentPage: 1,
+  filterType: "닉네임 + 하모니룸 이름",
+  searchTerm: "",
+
+  setRooms: (rooms) => set({ rooms }),
+
+  setCurrentPage: (page) => set({ currentPage: page }),
+
+  setFilterType: (filter) => set({ filterType: filter }),
+
+  setSearchTerm: (term) => set({ searchTerm: term, currentPage: 1 }),
+}));

--- a/src/shared/stores/keyword.store.ts
+++ b/src/shared/stores/keyword.store.ts
@@ -1,0 +1,72 @@
+import { create } from "zustand";
+
+export type FilterType = "이름" | "구분" | "키워드";
+export type SortBy = "이름" | "구분" | "생성일";
+
+export type Keyword = {
+  id: number;
+  name: string;
+  category: string;
+  keywords: string[];
+};
+
+type KeywordState = {
+  selectedKeywords: number[];
+  keywords: Keyword[];
+  currentPage: number;
+  filterType: FilterType;
+  searchTerm: string;
+  sortBy: SortBy;
+
+  // Actions
+  toggleSelectKeyword: (id: number) => void;
+  toggleSelectAll: (ids: number[]) => void;
+  clearSelection: () => void;
+  setCurrentPage: (page: number) => void;
+  setFilterType: (filter: FilterType) => void;
+  setSearchTerm: (term: string) => void;
+  setSortBy: (sort: SortBy) => void;
+  setKeywords: (keywords: Keyword[]) => void;
+  deleteKeywords: (ids: number[]) => void;
+};
+
+export const useKeywordStore = create<KeywordState>((set) => ({
+  selectedKeywords: [],
+  keywords: [],
+  currentPage: 1,
+  filterType: "키워드",
+  searchTerm: "",
+  sortBy: "이름",
+
+  toggleSelectKeyword: (id) =>
+    set((state) => ({
+      selectedKeywords: state.selectedKeywords.includes(id)
+        ? state.selectedKeywords.filter((kid) => kid !== id)
+        : [...state.selectedKeywords, id],
+    })),
+
+  toggleSelectAll: (ids) =>
+    set((state) => ({
+      selectedKeywords:
+        state.selectedKeywords.length === ids.length ? [] : ids,
+    })),
+
+  clearSelection: () => set({ selectedKeywords: [] }),
+
+  setCurrentPage: (page) => set({ currentPage: page }),
+
+  setFilterType: (filter) => set({ filterType: filter }),
+
+  setSearchTerm: (term) => set({ searchTerm: term, currentPage: 1 }),
+
+  setSortBy: (sort) => set({ sortBy: sort }),
+
+  setKeywords: (keywords) => set({ keywords }),
+
+  deleteKeywords: (ids) =>
+    set((state) => ({
+      keywords: state.keywords.filter((kw) => !ids.includes(kw.id)),
+      selectedKeywords: [],
+      currentPage: 1,
+    })),
+}));

--- a/src/shared/styles/Table.ts
+++ b/src/shared/styles/Table.ts
@@ -4,10 +4,15 @@ export const TableSection = styled.div`
   border-radius: ${({ theme }) => theme.radius.md};
 `;
 
-export const TableHeader = styled.div`
-  display: flex;
+type GridProps = {
+  columns?: string; // 예: "200px 150px 1fr 120px"
+};
+
+export const TableHeader = styled.div<GridProps>`
+  display: grid;
+  grid-template-columns: ${({ columns }) => columns ?? "1fr"};
   align-items: center;
-  padding: 8px 10px;
+  padding: 8px 20px;
   background-color: ${({ theme }) => theme.colors.white};
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray_100};
 `;
@@ -18,10 +23,11 @@ export const TableBody = styled.div`
   background-color: ${({ theme }) => theme.colors.white};
 `;
 
-export const TableRow = styled.div`
-  display: flex;
+export const TableRow = styled.div<GridProps>`
+  display: grid;
+  grid-template-columns: ${({ columns }) => columns ?? "1fr"};
   align-items: center;
-  padding: 8px 10px;
+  padding: 8px 20px;
   border-bottom: 1px solid ${({ theme }) => theme.colors.gray_100};
   background-color: ${({ theme }) => theme.colors.white};
 `;

--- a/src/shared/styles/Table.ts
+++ b/src/shared/styles/Table.ts
@@ -32,17 +32,30 @@ export const TableRow = styled.div<GridProps>`
   background-color: ${({ theme }) => theme.colors.white};
 `;
 
-export const TableCol = styled.div<{ width?: string }>`
+export const TableCol = styled.div<{ width?: string, ellipsis?: boolean }>`
   display: flex;
   align-items: center;
   height: 48px;
-  width: ${({ width }) => width || "auto"};
+
+  min-width: 0;
+
+  /* width는 grid가 관리하니까 굳이 auto로 안 둬도 됨 */
+  width: ${({ width }) => width || "100%"};
+
   font-family: "Pretendard";
   font-size: 18px;
   font-weight: 400;
   line-height: 28px;
   color: ${({ theme }) => theme.colors.gray_400};
-  text-overflow: ellipsis;
+
+  ${({ ellipsis }) =>
+    ellipsis &&
+    `
+      max-width: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+  `}
 `;
 
 export const StyledCheckbox = styled.img`

--- a/src/shared/ui/CommonButton.tsx
+++ b/src/shared/ui/CommonButton.tsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 
 type Variant = "default" | "ghost" | "outline" | "ghostGray";
-type Size = "sm" | "lg";
+type Size = "sm" | "lg" | "md";
 
 interface ButtonProps {
   label?: string;
@@ -38,6 +38,12 @@ const variants = {
 const sizes = {
   sm: css`
     padding: 8px 10px;
+    font-size: 15px;
+    font-weight: 400;
+    line-height: 27px;
+  `,
+  md: css`
+    padding: 7px 24px;
     font-size: 15px;
     font-weight: 400;
     line-height: 27px;

--- a/src/shared/ui/CustomCalendar.tsx
+++ b/src/shared/ui/CustomCalendar.tsx
@@ -1,0 +1,235 @@
+import styled from "styled-components";
+import { DayPicker, useDayPicker } from "react-day-picker";
+import type { DateRange, MonthCaptionProps } from "react-day-picker";
+import { ko } from "react-day-picker/locale";
+import "react-day-picker/style.css";
+
+type Props = {
+  selectedRange?: DateRange;
+  onSelect: (range?: DateRange) => void;
+};
+
+export default function CustomCalendar({ selectedRange, onSelect }: Props) {
+  return (
+    <DayPickerWrap>
+      <DayPicker
+        mode="range"
+        locale={ko}
+        selected={selectedRange}
+        onSelect={(range) => onSelect(range)}
+        showOutsideDays
+        fixedWeeks
+        formatters={{
+          formatCaption: (date) => `${date.getMonth() + 1}`,
+        }}
+        components={{
+          MonthCaption: CustomCaption, // v9 기준
+        }}
+      />
+    </DayPickerWrap>
+  );
+}
+
+/** 커스텀 캡션 컴포넌트 */
+function CustomCaption({ calendarMonth }: MonthCaptionProps) {
+  const { goToMonth, nextMonth, previousMonth } = useDayPicker();
+
+  return (
+    <CaptionRow>
+      <NavButton
+        onClick={() => previousMonth && goToMonth(previousMonth)}
+        disabled={!previousMonth}
+        type="button"
+      >
+        ‹
+      </NavButton>
+
+      <MonthLabel>{calendarMonth.date.getMonth() + 1}</MonthLabel>
+
+      <NavButton
+        onClick={() => nextMonth && goToMonth(nextMonth)}
+        disabled={!nextMonth}
+        type="button"
+      >
+        ›
+      </NavButton>
+    </CaptionRow>
+  );
+}
+
+/* ===================== Styles ===================== */
+
+const DayPickerWrap = styled.div`
+  /* ── CSS 변수 재정의 ── */
+  .rdp-root {
+    --rdp-accent-color: ${({ theme }) => theme.colors.blue_normal};
+    --rdp-accent-background-color: ${({ theme }) => theme.colors.blue_light};
+    --rdp-range_start-color: #ffffff;
+    --rdp-range_start-background: ${({ theme }) => theme.colors.blue_normal};
+    --rdp-range_end-color: #ffffff;
+    --rdp-range_end-background: ${({ theme }) => theme.colors.blue_normal};
+    --rdp-range_middle-background-color: ${({ theme }) => theme.colors.blue_light};
+    --rdp-range_middle-color: ${({ theme }) => theme.colors.black};
+    --rdp-day_button-width: 34px;
+    --rdp-day_button-height: 34px;
+    --rdp-day-width: 34px;
+    --rdp-day-height: 34px;
+    margin: 0;
+  }
+
+  /* ── 월 레이아웃 ── */
+  .rdp-months {
+    justify-content: center;
+  }
+
+  /* ── 헤더 캡션 (월 표시 영역) ── */
+  .rdp-month_caption {
+    padding: 0;
+  }
+
+  .rdp-caption_label {
+    font-size: 16px;
+    font-weight: 700;
+    color: ${({ theme }) => theme.colors.black};
+  }
+
+  /* 기본 네비게이션 숨김(우리는 CustomCaption에서 구현) */
+  .rdp-nav {
+    display: none;
+  }
+
+  /* ── 요일 헤더 ── */
+  .rdp-weekday {
+    font-size: 12px;
+    font-weight: 500;
+    color: ${({ theme }) => theme.colors.gray_300};
+    width: var(--rdp-day-width);
+    padding-bottom: 8px;
+    text-align: center;
+  }
+
+  /* ── 날짜 셀 ── */
+  .rdp-day {
+    width: var(--rdp-day-width);
+    height: var(--rdp-day-height);
+    padding: 0;
+    text-align: center;
+  }
+
+  /* ── 날짜 버튼 ── */
+  .rdp-day_button {
+    width: var(--rdp-day_button-width);
+    height: var(--rdp-day_button-height);
+    border-radius: 50%;
+    border: none;
+    background: transparent;
+    font-size: 13px;
+    font-weight: 400;
+    color: ${({ theme }) => theme.colors.gray_500};
+    cursor: pointer;
+    transition: background 0.15s;
+
+    &:hover:not(:disabled) {
+      background: ${({ theme }) => theme.colors.gray_100};
+    }
+  }
+
+  /* ── 오늘 날짜 ── */
+  .rdp-today .rdp-day_button {
+    font-weight: 800;
+    color: ${({ theme }) => theme.colors.blue_normal_active};
+  }
+
+  /* ── 범위 중간 ── */
+  .rdp-range_middle {
+    background: ${({ theme }) => theme.colors.blue_light};
+
+    .rdp-day_button {
+      border-radius: 8px;
+      color: ${({ theme }) => theme.colors.gray_500};
+      background: transparent;
+    }
+  }
+
+  /* ── 범위 시작 ── */
+  .rdp-range_start {
+    background: linear-gradient(
+      to right,
+      transparent 50%,
+      ${({ theme }) => theme.colors.blue_light} 50%
+    );
+
+    .rdp-day_button {
+      background: ${({ theme }) => theme.colors.blue_normal_active} !important;
+      color: #ffffff !important;
+      border-radius: 50% !important;
+    }
+  }
+
+  /* ── 범위 끝 ── */
+  .rdp-range_end {
+    background: linear-gradient(
+      to left,
+      transparent 50%,
+      ${({ theme }) => theme.colors.blue_light} 50%
+    );
+
+    .rdp-day_button {
+      background: ${({ theme }) => theme.colors.blue_normal_active} !important;
+      color: #ffffff !important;
+      border-radius: 50% !important;
+    }
+  }
+
+  /* ── 단일 날짜만 선택 ── */
+  .rdp-range_start.rdp-range_end {
+    background: transparent;
+  }
+
+  /* ── 월 바깥 날짜 ── */
+  .rdp-outside .rdp-day_button {
+    color: ${({ theme }) => theme.colors.gray_300};
+  }
+
+  /* ── 비활성 날짜 ── */
+  .rdp-disabled .rdp-day_button {
+    cursor: not-allowed;
+    color: ${({ theme }) => theme.colors.gray_300};
+  }
+`;
+
+const CaptionRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 4px 0 12px;
+`;
+
+const MonthLabel = styled.span`
+  font-size: 16px;
+  font-weight: 700;
+  min-width: 24px;
+  text-align: center;
+  color: ${({ theme }) => theme.colors.black};
+`;
+
+const NavButton = styled.button`
+  background: transparent;
+  border: none;
+  font-size: 18px;
+  color: ${({ theme }) => theme.colors.gray_400};
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: 6px;
+  line-height: 1;
+
+  &:hover:not(:disabled) {
+    background: ${({ theme }) => theme.colors.gray_100};
+  }
+
+  &:disabled {
+    opacity: 0.35;
+    cursor: not-allowed;
+  }
+`;

--- a/src/shared/ui/InputField.tsx
+++ b/src/shared/ui/InputField.tsx
@@ -1,0 +1,191 @@
+// InputField.tsx
+import styled, { css } from "styled-components";
+
+type Variant = "default" | "error" | "disabled";
+type FieldSize = "short" | "long" | "full";
+
+interface BaseProps {
+  value: string;
+  placeholder?: string;
+  disabled?: boolean;
+  error?: boolean;
+  maxLength?: number;
+  onChange: (value: string) => void;
+  className?: string;
+}
+
+interface SingleLineProps extends BaseProps {
+  type?: React.HTMLInputTypeAttribute;
+  autoComplete?: string;
+}
+
+interface MultiLineProps extends BaseProps {
+  rows?: number;
+}
+
+const variants = {
+  default: css`
+    border: 1px solid ${({ theme }) => theme.colors.gray_200};
+    background: ${({ theme }) => theme.colors.white};
+  `,
+  error: css`
+    border: 1px solid ${({ theme }) => theme.colors.danger ?? "#FF4D4F"};
+    background: ${({ theme }) => theme.colors.white};
+  `,
+  disabled: css`
+    border: 1px solid ${({ theme }) => theme.colors.gray_200};
+    background: ${({ theme }) => theme.colors.white ?? "#ffffff"};
+  `,
+};
+
+const sizes = {
+  short: css`
+    width: 208px;
+    max-width: 100%;
+  `,
+  long: css`
+    width: 100%;
+  `,
+  full: css`
+    width: 100%;
+  `,
+};
+
+/* =========================
+   긴 한 줄 입력 (제목)
+   ========================= */
+export function LongSingleInput({
+  value,
+  onChange,
+  placeholder = "제목을 입력해 주세요.",
+  disabled,
+  error,
+  maxLength,
+  type = "text",
+  autoComplete,
+  className,
+}: SingleLineProps) {
+  const variant: Variant = disabled ? "disabled" : error ? "error" : "default";
+
+  return (
+    <Input
+      className={className}
+      type={type}
+      value={value}
+      placeholder={placeholder}
+      disabled={disabled}
+      maxLength={maxLength}
+      autoComplete={autoComplete}
+      $variant={variant}
+      $size="long"
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
+/* =========================
+   여러 줄 입력 (내용)
+   ========================= */
+export function MultiLineInput({
+  value,
+  onChange,
+  placeholder = "내용을 입력해 주세요.",
+  disabled,
+  error,
+  maxLength,
+  rows = 10,
+  className,
+}: MultiLineProps) {
+  const variant: Variant = disabled ? "disabled" : error ? "error" : "default";
+
+  return (
+    <TextArea
+      className={className}
+      value={value}
+      placeholder={placeholder}
+      disabled={disabled}
+      maxLength={maxLength}
+      rows={rows}
+      $variant={variant}
+      $size="full"
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
+/* =========================
+   짧은 단답 입력 (담당자 이름)
+   ========================= */
+export function ShortSingleInput({
+  value,
+  onChange,
+  placeholder = "이름",
+  disabled,
+  error,
+  maxLength,
+  type = "text",
+  autoComplete,
+  className,
+}: SingleLineProps) {
+  const variant: Variant = disabled ? "disabled" : error ? "error" : "default";
+
+  return (
+    <Input
+      className={className}
+      type={type}
+      value={value}
+      placeholder={placeholder}
+      disabled={disabled}
+      maxLength={maxLength}
+      autoComplete={autoComplete}
+      $variant={variant}
+      $size="short"
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}
+
+/* =========================
+   공통 스타일
+   ========================= */
+
+const baseStyle = css`
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-family: "Pretendard";
+  font-size: 15px;
+  font-weight: 400;
+  line-height: 27px;
+  letter-spacing: -0.02em;
+  outline: none;
+  transition: border-color 0.15s ease, opacity 0.15s ease;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.gray_400};
+  }
+
+  &:focus {
+    border-color: ${({ theme }) =>
+      theme.colors.blue_normal};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+`;
+
+const Input = styled.input<{ $variant: Variant; $size: FieldSize }>`
+  ${baseStyle}
+  ${({ $variant }) => variants[$variant]}
+  ${({ $size }) => sizes[$size]}
+`;
+
+const TextArea = styled.textarea<{ $variant: Variant; $size: FieldSize }>`
+  ${baseStyle}
+  ${({ $variant }) => variants[$variant]}
+  ${({ $size }) => sizes[$size]}
+  height: 190px;
+  min-height: 190px;
+  resize: vertical;
+`;

--- a/src/shared/ui/Popup.tsx
+++ b/src/shared/ui/Popup.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import styled from "styled-components";
+import CommonButton from "./CommonButton";
+
+type PopupProps = {
+  open: boolean;
+  onClose: () => void;
+
+  /** 버튼 텍스트 */
+  cancelText: string;
+  confirmText: string;
+
+  /** 버튼 핸들러 */
+  onCancel?: () => void; // 없으면 onClose로 처리
+  onConfirm: () => void;
+
+  /** children으로 내용 구성 */
+  children: React.ReactNode;
+
+  /** 옵션 */
+  closeOnBackdrop?: boolean; // 기본 true
+  width?: number; // 기본 760
+};
+
+export default function Popup({
+  open,
+  onClose,
+  cancelText,
+  confirmText,
+  onCancel,
+  onConfirm,
+  children,
+  closeOnBackdrop = true,
+  width = 760,
+}: PopupProps) {
+  if (!open) return null;
+
+  const handleBackdropClick = () => {
+    if (closeOnBackdrop) onClose();
+  };
+
+  const handleCancel = () => {
+    (onCancel ?? onClose)();
+  };
+
+  return (
+    <Backdrop onMouseDown={handleBackdropClick}>
+      <Dialog
+        $width={width}
+        role="dialog"
+        aria-modal="true"
+        onMouseDown={(e) => e.stopPropagation()} // 바깥 클릭만 닫히게
+      >
+        <Content>{children}</Content>
+
+        <Footer>
+          <CommonButton size="md" variant="ghost" onClick={handleCancel} label={cancelText}/>
+          <CommonButton size="md" variant="default" onClick={onConfirm} label={confirmText}/>
+        </Footer>
+      </Dialog>
+    </Backdrop>
+  );
+}
+
+/* ===================== styles ===================== */
+
+const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 9999;
+`;
+
+const Dialog = styled.div<{ $width: number }>`
+  width: ${({ $width }) => $width}px;
+  max-width: 100%;
+  background: ${({ theme }) => theme.colors?.white ?? "#fff"};
+  border-radius: 8px;
+  box-shadow: 0 12px 4px rgba(16, 24, 40, 0.08);
+  padding: 54px 60px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+const Content = styled.div`
+  /* children의 p태그들이 "라벨 / 값"처럼 보이게 */
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 36px;
+
+  div {
+    display: flex;
+    flex-direction: column;
+  }
+
+  p {
+    margin: 0;
+    font-family: "Pretendard";
+  }
+
+  /* 홀수번째 p: 라벨 */
+  p:nth-child(odd) {
+    font-size: 18px;
+    font-weight: 700;
+    color: ${({ theme }) => theme.colors.black};
+    margin-bottom: 10px;
+  }
+
+  /* 짝수번째 p: 값 */
+  p:nth-child(even) {
+    font-size: 18px;
+    font-weight: 400;
+    color: ${({ theme }) => theme.colors?.gray_400};
+  }
+`;
+
+const Footer = styled.div`
+  margin-top: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+`;

--- a/src/shared/ui/SearchSelect.tsx
+++ b/src/shared/ui/SearchSelect.tsx
@@ -16,7 +16,7 @@ type Props = {
   className?: string;
   chevronUpIcon: string;
   chevronDownIcon: string;
-  checkIcon: string;
+  checkIcon?: string;
 };
 
 export default function SearchSelect({


### PR DESCRIPTION
## 📌 이슈 번호
> ex) #3 

## 💬 리뷰 포인트
> table 스타일 변경(grid), 키워드 및 하모니룸 페이지 구현, 캘린더 페이지 구현, 하모니룸 상세 페이지 구현

## 🚀 상세 설명
> 컴포넌트 생성
- `InputField.tsx` - 인풋 필드 (한줄 / 여러줄 / 단답) 타입별 구분
- `Popup.tsx` - 마지막 확인 팝업 구현 (하모니룸 상세 페이지 / 문의 확인 페이지에서 사용 가능)
- `CustomButton.tsx` - "md" 사이즈 추가 -> "1개선택" 이 버튼 제외 나머지 "저장", "답변완료" 는 size = md로 사용 가능 (패딩 맞춰놈)
- `CustomCalendar.tsx` - react-day-picker 라이브러리 사용해 커스텀 캘린더 구현 (캘린더 페이지, 공지사항작성 페이지 사용가능)

## 📸 스크린샷
<img width="1463" height="742" alt="image" src="https://github.com/user-attachments/assets/3288460e-9526-4ca9-8333-4ad66a952a55" />
<img width="1460" height="741" alt="image" src="https://github.com/user-attachments/assets/288f51e4-3bab-4596-8af4-4aed13dcf756" />
<img width="1463" height="741" alt="image" src="https://github.com/user-attachments/assets/0678246f-ee8c-4d31-be29-d952bf917577" />
<img width="1461" height="742" alt="image" src="https://github.com/user-attachments/assets/96a5a44c-afec-4057-8312-6f3bde980dc5" />
<img width="1454" height="743" alt="image" src="https://github.com/user-attachments/assets/d2b63f61-9cc3-4723-bf77-3732d98915ce" />


## 📢 노트
```npm i react-date-picker```
=> 부탁드립니다!