### PR TITLE
✨ feat : 탈퇴&폐쇄 통계 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-day-picker": "^9.13.2",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.12.0",
+        "recharts": "^2.15.4",
         "styled-components": "^6.3.8",
         "zod": "^4.3.5",
         "zustand": "^5.0.10"
@@ -267,6 +268,14 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1471,6 +1480,60 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2155,6 +2218,116 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -2189,6 +2362,11 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2203,6 +2381,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -2520,12 +2707,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -2868,6 +3068,14 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2902,7 +3110,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3005,12 +3212,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -3103,6 +3326,14 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3251,6 +3482,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3313,7 +3554,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {
@@ -3362,6 +3602,70 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3570,6 +3874,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -3703,6 +4012,27 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react-day-picker": "^9.13.2",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.12.0",
+    "recharts": "^2.15.4",
     "styled-components": "^6.3.8",
     "zod": "^4.3.5",
     "zustand": "^5.0.10"

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,12 +1,18 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "styled-components";
 import { GlobalStyle } from "../shared/styles/globalStyle";
 import { theme } from "../shared/styles/theme";
 
-export default function AppProviders({ children }: { children: React.ReactNode }) {
+const queryClient = new QueryClient();
+
+export default function AppProviders({ children }: { children: ReactNode }) {
   return (
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      {children}
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        {children}
+      </ThemeProvider>
+    </QueryClientProvider>
   );
 }

--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -7,6 +7,7 @@ import KeywordPage from "../pages/KeywordPage";
 import QnA from "../pages/QnAPage";
 import HarmonyRoomDetailPage from "../pages/HarmonyRoomDetailPage";
 import CalendarPage from "../pages/CalendarPage";
+import LeaveStatisticsPage from "../pages/leaveStatisticsPage";
 
 
 export const router = createBrowserRouter([
@@ -23,7 +24,7 @@ export const router = createBrowserRouter([
       { path: "QnA", element: <QnA /> },
       { path: "notice", element: <HarmonyRoomPage /> },
       { path: "userstatistics", element: <HarmonyRoomPage /> },
-      { path: "leavestatistics", element: <HarmonyRoomPage /> },
+      { path: "leavestatistics", element: <LeaveStatisticsPage /> },
       { path: "server", element: <HarmonyRoomPage /> },
     ],
   },

--- a/src/hooks/useExitStatisticsQuery.ts
+++ b/src/hooks/useExitStatisticsQuery.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+  getHarmonyExitStatistics,
+  getServiceExitStatistics,
+  type ExitStatisticItem,
+} from "../shared/api/exitStatistics";
+
+type ExitStatisticTab = "serviceLeave" | "roomClose";
+
+type UseExitStatisticsQueryParams = {
+  tab: ExitStatisticTab;
+  searchType: string;
+  startDay: string | null;
+  endDay: string | null;
+};
+
+export function useExitStatisticsQuery({
+  tab,
+  searchType,
+  startDay,
+  endDay,
+}: UseExitStatisticsQueryParams) {
+  return useQuery<ExitStatisticItem[]>({
+    queryKey: ["exitStatistics", tab, searchType, startDay, endDay],
+    queryFn: () =>
+      tab === "serviceLeave"
+        ? getServiceExitStatistics({ searchType, startDay, endDay })
+        : getHarmonyExitStatistics({ searchType, startDay, endDay }),
+  });
+}

--- a/src/pages/leaveStatisticsPage.tsx
+++ b/src/pages/leaveStatisticsPage.tsx
@@ -1,0 +1,312 @@
+import { useMemo, useState } from "react";
+import styled from "styled-components";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+// import { useExitStatisticsQuery } from "../hooks/useExitStatisticsQuery";
+import type { ExitStatisticItem } from "../shared/api/exitStatistics";
+import { MOCK_LEAVE_STATISTICS } from "../shared/constants/mockData";
+import SearchSelect from "../shared/ui/SearchSelect";
+
+import chevronUp from "../assets/icons/ChevronUp.svg";
+import check from "../assets/icons/CheckIcon.svg";
+
+type StatisticTab = "serviceLeave" | "roomClose";
+
+type ChartDatum = {
+  label: string;
+  count: number;
+};
+
+const YEAR_OPTIONS = [
+  { label: "전체", value: "" },
+  { label: "2026년", value: "2026" },
+  { label: "2025년", value: "2025" },
+  { label: "2024년", value: "2024" },
+];
+
+const DATE_OPTIONS = [
+  { label: "전체", value: "" },
+  { label: "01월 20일", value: "01-20" },
+  { label: "01월 21일", value: "01-21" },
+  { label: "01월 22일", value: "01-22" },
+  { label: "01월 25일", value: "01-25" },
+  { label: "02월 22일", value: "02-22" },
+];
+
+const TIME_RANGE_OPTIONS = [
+  { label: "전체 시간", value: "all" },
+  { label: "00-06시", value: "00-06" },
+  { label: "06-12시", value: "06-12" },
+  { label: "12-18시", value: "12-18" },
+  { label: "18-24시", value: "18-24" },
+];
+
+const SERVICE_REASON_LABELS: Record<string, string> = {
+  "0": "기능이 복잡해요",
+  "1": "원하는 정보를 찾기 어려워요",
+  "2": "취향에 맞는 콘텐츠가 부족해요",
+  "3": "오류가 발생했어요",
+  "4": "다른 유사 서비스를 사용해요",
+};
+
+const HARMONY_REASON_LABELS: Record<string, string> = {
+  "1": "멤버 참여율이 낮아요",
+  "2": "관심 주제가 변경됐어요",
+  "3": "기술적인 문제가 있어요",
+  "4": "시간 부족 등 개인적인 이유예요",
+};
+
+export default function LeaveStatisticsPage() {
+  const [tab, setTab] = useState<StatisticTab>("serviceLeave");
+  const [startYear, setStartYear] = useState("");
+  const [startDate, setStartDate] = useState("");
+  const [endYear, setEndYear] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [timeRange, setTimeRange] = useState("all");
+
+  // todo : api 연동 후 주석 제거
+  // const startDay = useMemo(
+  //   () => buildRequestDate(startYear, startDate),
+  //   [startYear, startDate]
+  // );
+  // const endDay = useMemo(() => buildRequestDate(endYear, endDate), [endYear, endDate]);
+  //
+  // const { data, isLoading, isError } = useExitStatisticsQuery({
+  //   tab,
+  //   searchType: timeRange,
+  //   startDay,
+  //   endDay,
+  // });
+
+  const data = useMemo<ExitStatisticItem[]>(() => {
+    return tab === "serviceLeave"
+      ? MOCK_LEAVE_STATISTICS.serviceLeave
+      : MOCK_LEAVE_STATISTICS.roomClose;
+  }, [tab]);
+
+  const chartData = useMemo<ChartDatum[]>(() => {
+    const labels = tab === "serviceLeave" ? SERVICE_REASON_LABELS : HARMONY_REASON_LABELS;
+
+    return data.map((item) => ({
+      label: labels[item.division] ?? item.division,
+      count: item.num,
+    }));
+  }, [data, tab]);
+
+  const yAxisMax = useMemo(() => {
+    if (chartData.length === 0) return 100;
+
+    const maxValue = Math.max(...chartData.map((item) => item.count));
+    return Math.max(100, Math.ceil(maxValue / 100) * 100);
+  }, [chartData]);
+
+  return (
+    <Container>
+      <Header>
+        <Tabs>
+          <TabButton
+            type="button"
+            $active={tab === "serviceLeave"}
+            onClick={() => setTab("serviceLeave")}
+          >
+            서비스 탈퇴
+          </TabButton>
+          <TabButton
+            type="button"
+            $active={tab === "roomClose"}
+            onClick={() => setTab("roomClose")}
+          >
+            하모니룸 폐쇄
+          </TabButton>
+        </Tabs>
+      </Header>
+
+      <Toolbar>
+        <Filters>
+          <SearchSelect
+            options={YEAR_OPTIONS}
+            value={startYear}
+            onChange={setStartYear}
+            size="md"
+            chevronUpIcon={chevronUp}
+            chevronDownIcon={chevronUp}
+            checkIcon={check}
+            placeholder="시작 연도"
+          />
+          <SearchSelect
+            options={DATE_OPTIONS}
+            value={startDate}
+            onChange={setStartDate}
+            size="md"
+            chevronUpIcon={chevronUp}
+            chevronDownIcon={chevronUp}
+            checkIcon={check}
+            placeholder="시작 날짜"
+          />
+          <RangeDivider>~</RangeDivider>
+          <SearchSelect
+            options={YEAR_OPTIONS}
+            value={endYear}
+            onChange={setEndYear}
+            size="md"
+            chevronUpIcon={chevronUp}
+            chevronDownIcon={chevronUp}
+            checkIcon={check}
+            placeholder="종료 연도"
+          />
+          <SearchSelect
+            options={DATE_OPTIONS}
+            value={endDate}
+            onChange={setEndDate}
+            size="md"
+            chevronUpIcon={chevronUp}
+            chevronDownIcon={chevronUp}
+            checkIcon={check}
+            placeholder="종료 날짜"
+          />
+          <TimeRangeSelect
+            options={TIME_RANGE_OPTIONS}
+            value={timeRange}
+            onChange={setTimeRange}
+            size="lg"
+            chevronUpIcon={chevronUp}
+            chevronDownIcon={chevronUp}
+            checkIcon={check}
+          />
+        </Filters>
+      </Toolbar>
+
+      <ChartCard>
+        <ChartArea>
+          {chartData.length === 0 ? (
+            <StatusMessage>조회할 데이터가 없습니다.</StatusMessage>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={chartData}
+                margin={{ top: 8, right: 12, left: 0, bottom: 24 }}
+                barCategoryGap={36}
+              >
+                <CartesianGrid vertical={false} stroke="#BDCAD8" />
+                <XAxis
+                  dataKey="label"
+                  tickLine={false}
+                  axisLine={false}
+                  interval={0}
+                  tick={{ fill: "#40474C", fontSize: 12 }}
+                />
+                <YAxis
+                  domain={[0, yAxisMax]}
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fill: "#BDCAD8", fontSize: 12 }}
+                />
+                <Tooltip
+                  formatter={(value) => [`${value}건`, "건수"]}
+                  cursor={{ fill: "rgba(117, 199, 234, 0.08)" }}
+                  contentStyle={{
+                    borderRadius: 12,
+                    border: "1px solid #BDCAD8",
+                    boxShadow: "0 12px 24px rgba(16, 24, 40, 0.08)",
+                  }}
+                />
+                <Bar dataKey="count" radius={[2, 2, 0, 0]} maxBarSize={34}>
+                  {chartData.map((entry) => (
+                    <Cell key={entry.label} fill="#75C7EA" />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </ChartArea>
+      </ChartCard>
+    </Container>
+  );
+}
+
+const Container = styled.div`
+  padding: 24px 72px;
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const Header = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 24px;
+`;
+
+const Toolbar = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 24px;
+  margin-bottom: 24px;
+`;
+
+const Tabs = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+`;
+
+const TabButton = styled.button<{ $active: boolean }>`
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  color: ${({ theme, $active }) =>
+    $active ? theme.colors.black : theme.colors.gray_300};
+  font-size: 24px;
+  font-weight: ${({ $active }) => ($active ? 700 : 500)};
+`;
+
+const Filters = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+`;
+
+const RangeDivider = styled.span`
+  color: ${({ theme }) => theme.colors.gray_400};
+  font-size: 18px;
+  font-weight: 500;
+`;
+
+const TimeRangeSelect = styled(SearchSelect)`
+  min-width: 242px;
+`;
+
+const ChartCard = styled.section`
+  min-height: 500px;
+  padding: 28px 28px 20px;
+  background: ${({ theme }) => theme.colors.white};
+  border-radius: 14px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+`;
+
+const ChartArea = styled.div`
+  width: 100%;
+  height: 400px;
+`;
+
+const StatusMessage = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  color: ${({ theme }) => theme.colors.gray_400};
+  font-size: 16px;
+  font-weight: 500;
+`;

--- a/src/shared/api/exitStatistics.ts
+++ b/src/shared/api/exitStatistics.ts
@@ -1,0 +1,51 @@
+import { api } from "./axios";
+
+export type ExitStatisticDivision = string;
+
+export type ExitStatisticItem = {
+  division: ExitStatisticDivision;
+  num: number;
+};
+
+type ExitStatisticResponse = {
+  success: boolean;
+  code: number;
+  message: string;
+  data: ExitStatisticItem[];
+};
+
+export type ExitStatisticParams = {
+  searchType: string;
+  startDay: string | null;
+  endDay: string | null;
+};
+
+// GET /api/admin/exit/service : 서비스 탈퇴 통계 조회
+export async function getServiceExitStatistics(params: ExitStatisticParams) {
+  const response = await api.request<ExitStatisticResponse>({
+    method: "GET",
+    url: "/api/admin/exit/service",
+    params: { searchType: params.searchType },
+    data: {
+      startDay: params.startDay,
+      endDay: params.endDay,
+    },
+  });
+
+  return response.data.data ?? [];
+}
+
+// GET /api/admin/exit/haramony : 하모니룸 폐쇄 통계 조회
+export async function getHarmonyExitStatistics(params: ExitStatisticParams) {
+  const response = await api.request<ExitStatisticResponse>({
+    method: "GET",
+    url: "/api/admin/exit/haramony",
+    params: { searchType: params.searchType },
+    data: {
+      startDay: params.startDay,
+      endDay: params.endDay,
+    },
+  });
+
+  return response.data.data ?? [];
+}

--- a/src/shared/constants/mockData.ts
+++ b/src/shared/constants/mockData.ts
@@ -463,3 +463,19 @@ export const MOCK_CALENDAR : Calendar[] = [
     name: "홍길동의 소나타"
   },
 ]
+
+export const MOCK_LEAVE_STATISTICS = {
+  serviceLeave: [
+    { division: "0", num: 148 },
+    { division: "1", num: 93 },
+    { division: "2", num: 74 },
+    { division: "3", num: 39 },
+    { division: "4", num: 57 },
+  ],
+  roomClose: [
+    { division: "1", num: 121 },
+    { division: "2", num: 88 },
+    { division: "3", num: 46 },
+    { division: "4", num: 63 },
+  ],
+};


### PR DESCRIPTION

## 💬 리뷰 포인트
* 탈퇴&폐쇄 통계 페이지 구현

## 🚀 상세 설명
* rechart를 사용하여 탈퇴&폐쇄 통계 페이지 구현
* api 로직도 구현하였지만 주석처리
* 현재는 ./constant/mockData에서 목업 데이터 가져와서 화면에 표시

## 📸 스크린샷
<img width="2880" height="1704" alt="image" src="https://github.com/user-attachments/assets/993cbbbc-6994-472f-b946-ca9c40c52960" />


## 📢 노트
* rechart 라이브러리 추가되었으므로 npm install 필요
